### PR TITLE
Correções e Incrementos

### DIFF
--- a/Cielo/Authorization.cs
+++ b/Cielo/Authorization.cs
@@ -30,7 +30,7 @@ namespace Cielo
 		/// <summary>
 		/// O código LR da autorização
 		/// </summary>
-		public int lr { get; set; }
+		public string lr { get; set; }
 
 		/// <summary>
 		/// O código ARP da autorização

--- a/Cielo/Cielo.cs
+++ b/Cielo/Cielo.cs
@@ -411,5 +411,16 @@ namespace Cielo
 			TransactionRequest request = TransactionRequest.create (transaction);
 			return TransacaoElement.unserialize (transaction, sendHttpRequest (serialize (request)));
 		}
-	}
+
+        /// <summary>
+        /// Envia uma requisição de consulta
+        /// </summary>
+        /// <param name="tid">TID da operação</param>        
+        /// <returns>Uma instância de Transaction com a resposta da requisição</returns>
+        public Transaction consultationRequest(String tid)
+        {
+            ConsultationRequest request = ConsultationRequest.create(tid, merchant);
+            return TransacaoElement.unserialize(null, sendHttpRequest(serialize(request)));
+        }
+    }
 }

--- a/Cielo/Cielo.csproj
+++ b/Cielo/Cielo.csproj
@@ -39,12 +39,14 @@
     <Reference Include="System.Net" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CieloException.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Cielo.cs" />
     <Compile Include="Holder.cs" />
     <Compile Include="Merchant.cs" />
     <Compile Include="Order.cs" />
     <Compile Include="PaymentMethod.cs" />
+    <Compile Include="Request\ConsultationRequest.cs" />
     <Compile Include="Request\Element\TokenElement.cs" />
     <Compile Include="Transaction.cs" />
     <Compile Include="Token.cs" />

--- a/Cielo/CieloException.cs
+++ b/Cielo/CieloException.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace Cielo
+{
+    /// <summary>
+    /// Classe para captura do erro no XML
+    /// </summary>
+    public class CieloException : Exception
+    {
+        /// <summary>
+        /// Código do erro
+        /// </summary>
+        public string Code { get; }
+        /// <summary>
+        /// Construtor
+        /// </summary>
+        public CieloException()
+        {
+        }
+
+        /// <summary>
+        /// Construtor
+        /// </summary>
+        /// <param name="message">Mensagem de erro</param>
+        /// <param name="erroCode">Código do erro</param>
+        /// <param name="innerException">Exceção</param>
+        public CieloException(string message, string erroCode, Exception innerException) : base(message, innerException)
+        {
+            Code = erroCode;
+        }
+    }
+}

--- a/Cielo/Request/ConsultationRequest.cs
+++ b/Cielo/Request/ConsultationRequest.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Cielo.Request.Element;
+using System;
+using System.Xml.Serialization;
+using System.ComponentModel;
+
+
+namespace Cielo.Request
+{
+    [SerializableAttribute()]
+    [DesignerCategoryAttribute("code")]
+    [XmlTypeAttribute(Namespace = "http://ecommerce.cbmp.com.br")]
+    [XmlRootAttribute("requisicao-consulta", Namespace = "http://ecommerce.cbmp.com.br", IsNullable = false)]
+    public partial class ConsultationRequest : AbstractElement
+    {
+        public String tid { get; set; }
+
+        [XmlElementAttribute("dados-ec")]
+        public DadosEcElement dadosEc { get; set; }
+
+        public static ConsultationRequest create(String tid, Merchant merchant)
+        {
+            return new ConsultationRequest
+            {
+                id = Guid.NewGuid().ToString(),
+                versao = Cielo.VERSION,
+                tid = tid,
+                dadosEc = new DadosEcElement
+                {
+                    numero = merchant.id,
+                    chave = merchant.key
+                }
+            };
+        }
+    }
+}

--- a/Cielo/Request/Element/AbstractElement.cs
+++ b/Cielo/Request/Element/AbstractElement.cs
@@ -27,8 +27,8 @@ namespace Cielo.Request.Element
 
 					ErroElement erro = (ErroElement)serializer.Deserialize (reader);
 
-					throw new Exception (erro.mensagem, e);
-				}
+					throw new CieloException(erro.mensagem, erro.codigo, e);
+                }
 			}
 
 			return element;

--- a/Cielo/Request/Element/AutorizacaoElement.cs
+++ b/Cielo/Request/Element/AutorizacaoElement.cs
@@ -17,7 +17,7 @@ namespace Cielo.Request.Element
 
 		public int valor { get; set; }
 
-		public int lr { get; set; }
+		public string lr { get; set; }
 
 		public string arp { get; set; }
 

--- a/Cielo/Request/Element/TransacaoElement.cs
+++ b/Cielo/Request/Element/TransacaoElement.cs
@@ -60,6 +60,14 @@ namespace Cielo.Request.Element
                 transaction.token = transacao.token.ToToken();
             }
 
+            int status = 0;
+            if (int.TryParse(transacao.status, out status))
+            {
+                transaction.status = status;
+            }            
+
+            transaction.authenticationUrl = transacao.urlAutenticacao;
+
             return transaction;
         }
     }

--- a/README.md
+++ b/README.md
@@ -45,12 +45,27 @@ try {
 		                          false
 	                          );
 
-	if (transaction.authorization != null && transaction.authorization.lr == 0) {
+	if (transaction.authorization != null && transaction.authorization.lr == "00") {
 		Console.Write ("Transação autorizada com sucesso. TID=");
 		Console.WriteLine (transaction.tid);
 	}
-} catch (Exception e) {
+} catch (CieloException e) {
 	Console.WriteLine ("Opz..");
+	Console.WriteLine (e.Code);
+	Console.WriteLine (e.Message);
+}
+```
+
+## Exemplo de consulta
+
+```csharp
+//...
+
+
+try {
+	transaction = cielo.consultationRequest ("1006993069000654F07A"); // tid da transação
+} catch (CieloException e) {
+	Console.WriteLine (e.Code);
 	Console.WriteLine (e.Message);
 }
 ```
@@ -63,8 +78,9 @@ try {
 
 try {
 	transaction = cielo.cancellationRequest (transaction);
-} catch (Exception e) {
-	// ...
+} catch (CieloException e) {
+	Console.WriteLine (e.Code);
+	Console.WriteLine (e.Message);
 }
 ```
 
@@ -76,8 +92,9 @@ try {
 
 try {
 	transaction = cielo.captureRequest (transaction);
-} catch (Exception e) {
-	// ...
+} catch (CieloException e) {
+	Console.WriteLine (e.Code);
+	Console.WriteLine (e.Message);
 }
 ```
 
@@ -89,7 +106,8 @@ try {
 
 try {
 	transaction = cielo.captureRequest (transaction, 10000);
-} catch (Exception e) {
-	// ...
+} catch (CieloException e) {
+	Console.WriteLine (e.Code);
+	Console.WriteLine (e.Message);
 }
 ```

--- a/TesteUnidadeCielo/Teste.cs
+++ b/TesteUnidadeCielo/Teste.cs
@@ -31,7 +31,7 @@ namespace TesteUnidadeCielo
 
             var codigoLr = transaction.authorization.lr;
 
-            Assert.AreEqual(codigoLr, 0);
+            Assert.AreEqual(codigoLr, "00");
         }
 
         [TestMethod]


### PR DESCRIPTION
Resolvido problema do status que estava vindo sempre com o valor 0, conforme dito no issue  28.
Adicionado CieloException para permitir pegar, além do texto, o código do erro.
Alerado campo lr para ser do tipo string, pois segundo a documentação, este campo pode receber alguns valores com caracteres.
Adicionado consultationRequest para fazer uma requisição de consulta.
Atualizado README do projeto com exemplo de requisição de consulta e uso da CieloException.