### PR TITLE
Inclusão do comando de instalação via NuGet

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Integração em C# com o Webservice Cielo 1.5
 
+## Setup
+
+Se preferir você pode pegar a versão mais recente diretamente do [pacote disponível](https://www.nuget.org/packages/CieloOficial/) na galeria do NuGet.
+
+> PM Install-Package CieloOficial
+
+
 ## Criando uma transação
 
 ```csharp


### PR DESCRIPTION
A fim de simplificar a instalação da biblioteca nos projetos criei um pacote e disponibilizei na galeria do NuGet, assim qualquer um que deseje utilizar esta integração poderá, sem muito esforço, incluí-la em seu projeto.

Seria interessante que os principais responsáveis pelo projeto me informassem seu nome de usuário no NuGet para que eu possa colocá-los como proprietários do pacote, assim qualquer um de nós poderíamos subir novas versões mantendo sempre atualizado com a versão do repositório.