### PR TITLE
Alteração do namespace da solução

### DIFF
--- a/Cielo.sln
+++ b/Cielo.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cielo", "Cielo\Cielo.csproj", "{69CC7192-A7E2-4990-9C99-430B4E822DA0}"
 EndProject

--- a/Cielo/Authentication.cs
+++ b/Cielo/Authentication.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Cielo
+namespace CieloEcommerce
 {
 	/// <summary>
 	/// Representa os dados de uma autenticação

--- a/Cielo/Authorization.cs
+++ b/Cielo/Authorization.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Cielo
+namespace CieloEcommerce
 {
 	/// <summary>
 	/// Representa os dados de uma autorização

--- a/Cielo/Cielo.cs
+++ b/Cielo/Cielo.cs
@@ -4,10 +4,10 @@ using System.Net;
 using System.Text;
 using System.Xml;
 using System.Xml.Serialization;
-using Cielo.Request;
-using Cielo.Request.Element;
+using CieloEcommerce.Request;
+using CieloEcommerce.Request.Element;
 
-namespace Cielo
+namespace CieloEcommerce
 {
 	/// <summary>
 	/// Integração com o Webservice 1.5 da Cielo; esse participante faz um

--- a/Cielo/Cielo.csproj
+++ b/Cielo/Cielo.csproj
@@ -5,8 +5,8 @@
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProjectGuid>{69CC7192-A7E2-4990-9C99-430B4E822DA0}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <RootNamespace>Cielo</RootNamespace>
-    <AssemblyName>Cielo</AssemblyName>
+    <RootNamespace>CieloEcommerce</RootNamespace>
+    <AssemblyName>CieloEcommerce</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <Description>Integração em C# com o Webservice Cielo 1.</Description>
   </PropertyGroup>
@@ -21,7 +21,7 @@
     <Externalconsole>true</Externalconsole>
     <PlatformTarget>x86</PlatformTarget>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
-    <DocumentationFile>bin\Debug\Cielo.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\CieloEcommerce.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <Optimize>true</Optimize>
@@ -30,7 +30,7 @@
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
     <PlatformTarget>x86</PlatformTarget>
-    <DocumentationFile>bin\Release\Cielo.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\CieloEcommerce.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Cielo/CieloException.cs
+++ b/Cielo/CieloException.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Cielo
+namespace CieloEcommerce
 {
     /// <summary>
     /// Classe para captura do erro no XML

--- a/Cielo/Holder.cs
+++ b/Cielo/Holder.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Cielo
+namespace CieloEcommerce
 {
 	/// <summary>
 	/// Representação do portador de um cartão

--- a/Cielo/Merchant.cs
+++ b/Cielo/Merchant.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Cielo
+namespace CieloEcommerce
 {
 	/// <summary>
 	/// Representa o vendedor ou ponto de venda

--- a/Cielo/Order.cs
+++ b/Cielo/Order.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Cielo
+namespace CieloEcommerce
 {
 	/// <summary>
 	/// Representa um pedido que a loja enviará para autorização na Cielo

--- a/Cielo/PaymentMethod.cs
+++ b/Cielo/PaymentMethod.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Cielo
+namespace CieloEcommerce
 {
 	/// <summary>
 	/// Representa o meio de pagamento escolhido pelo cliente

--- a/Cielo/Request/AuthorizationRequest.cs
+++ b/Cielo/Request/AuthorizationRequest.cs
@@ -1,20 +1,20 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Xml.Serialization;
-using Cielo.Request.Element;
+using CieloEcommerce.Request.Element;
 
-namespace Cielo.Request
+namespace CieloEcommerce.Request
 {
-	[SerializableAttribute ()]
-	[DesignerCategoryAttribute ("code")]
-	[XmlTypeAttribute (Namespace = "http://ecommerce.cbmp.com.br")]
-	[XmlRootAttribute ("requisicao-autorizacao-tid", Namespace = "http://ecommerce.cbmp.com.br", IsNullable = false)]
+	[Serializable ()]
+	[DesignerCategory ("code")]
+	[XmlType (Namespace = "http://ecommerce.cbmp.com.br")]
+	[XmlRoot ("requisicao-autorizacao-tid", Namespace = "http://ecommerce.cbmp.com.br", IsNullable = false)]
 	public partial class AuthorizationRequest :AbstractElement
 	{
-		[XmlElementAttribute ("tid")]
+		[XmlElement ("tid")]
 		public String tid { get; set; }
 
-		[XmlElementAttribute ("dados-ec")]
+		[XmlElement ("dados-ec")]
 		public DadosEcElement dadosEc { get; set; }
 
 		public static AuthorizationRequest create (Transaction transaction)

--- a/Cielo/Request/CancellationRequest.cs
+++ b/Cielo/Request/CancellationRequest.cs
@@ -1,20 +1,20 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Xml.Serialization;
-using Cielo.Request.Element;
+using CieloEcommerce.Request.Element;
 
-namespace Cielo.Request
+namespace CieloEcommerce.Request
 {
-	[SerializableAttribute ()]
-	[DesignerCategoryAttribute ("code")]
-	[XmlTypeAttribute (Namespace = "http://ecommerce.cbmp.com.br")]
-	[XmlRootAttribute ("requisicao-cancelamento", Namespace = "http://ecommerce.cbmp.com.br", IsNullable = false)]
+	[Serializable ()]
+	[DesignerCategory ("code")]
+	[XmlType (Namespace = "http://ecommerce.cbmp.com.br")]
+	[XmlRoot ("requisicao-cancelamento", Namespace = "http://ecommerce.cbmp.com.br", IsNullable = false)]
 	public partial class CancellationRequest :AbstractElement
 	{
-		[XmlElementAttribute ("tid")]
+		[XmlElement ("tid")]
 		public String tid { get; set; }
 
-		[XmlElementAttribute ("dados-ec")]
+		[XmlElement ("dados-ec")]
 		public DadosEcElement dadosEc { get; set; }
 
 		public int valor { get; set; }

--- a/Cielo/Request/CaptureRequest.cs
+++ b/Cielo/Request/CaptureRequest.cs
@@ -1,20 +1,20 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Xml.Serialization;
-using Cielo.Request.Element;
+using CieloEcommerce.Request.Element;
 
-namespace Cielo.Request
+namespace CieloEcommerce.Request
 {
-	[SerializableAttribute ()]
-	[DesignerCategoryAttribute ("code")]
-	[XmlTypeAttribute (Namespace = "http://ecommerce.cbmp.com.br")]
-	[XmlRootAttribute ("requisicao-captura", Namespace = "http://ecommerce.cbmp.com.br", IsNullable = false)]
+	[Serializable ()]
+	[DesignerCategory ("code")]
+	[XmlType (Namespace = "http://ecommerce.cbmp.com.br")]
+	[XmlRoot ("requisicao-captura", Namespace = "http://ecommerce.cbmp.com.br", IsNullable = false)]
 	public partial class CaptureRequest :AbstractElement
 	{
-		[XmlElementAttribute ("tid")]
+		[XmlElement ("tid")]
 		public String tid { get; set; }
 
-		[XmlElementAttribute ("dados-ec")]
+		[XmlElement ("dados-ec")]
 		public DadosEcElement dadosEc { get; set; }
 
 		public int valor { get; set; }

--- a/Cielo/Request/ConsultationRequest.cs
+++ b/Cielo/Request/ConsultationRequest.cs
@@ -1,21 +1,19 @@
 ﻿using System;
-using Cielo.Request.Element;
-using System;
-using System.Xml.Serialization;
 using System.ComponentModel;
+using System.Xml.Serialization;
+using CieloEcommerce.Request.Element;
 
-
-namespace Cielo.Request
+namespace CieloEcommerce.Request
 {
-    [SerializableAttribute()]
-    [DesignerCategoryAttribute("code")]
-    [XmlTypeAttribute(Namespace = "http://ecommerce.cbmp.com.br")]
-    [XmlRootAttribute("requisicao-consulta", Namespace = "http://ecommerce.cbmp.com.br", IsNullable = false)]
+    [Serializable()]
+    [DesignerCategory("code")]
+    [XmlType(Namespace = "http://ecommerce.cbmp.com.br")]
+    [XmlRoot("requisicao-consulta", Namespace = "http://ecommerce.cbmp.com.br", IsNullable = false)]
     public partial class ConsultationRequest : AbstractElement
     {
         public String tid { get; set; }
 
-        [XmlElementAttribute("dados-ec")]
+        [XmlElement("dados-ec")]
         public DadosEcElement dadosEc { get; set; }
 
         public static ConsultationRequest create(String tid, Merchant merchant)

--- a/Cielo/Request/Element/AbstractElement.cs
+++ b/Cielo/Request/Element/AbstractElement.cs
@@ -1,16 +1,15 @@
 ﻿using System;
-using System.Xml.Serialization;
 using System.IO;
-using System.Text;
+using System.Xml.Serialization;
 
-namespace Cielo.Request.Element
+namespace CieloEcommerce.Request.Element
 {
 	public class AbstractElement
 	{
-		[XmlAttributeAttribute ()]
+		[XmlAttribute ()]
 		public String id { get; set; }
 
-		[XmlAttributeAttribute ()]
+		[XmlAttribute ()]
 		public String versao { get; set; }
 
 		protected T unserializeElement<T> (T element, String response)

--- a/Cielo/Request/Element/AutenticacaoElement.cs
+++ b/Cielo/Request/Element/AutenticacaoElement.cs
@@ -1,18 +1,17 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Xml.Serialization;
 
-namespace Cielo.Request.Element
+namespace CieloEcommerce.Request.Element
 {
-	[SerializableAttribute ()]
-	[XmlTypeAttribute (Namespace = "http://ecommerce.cbmp.com.br")]
+	[Serializable ()]
+	[XmlType (Namespace = "http://ecommerce.cbmp.com.br")]
 	public partial class AutenticacaoElement :AbstractElement
 	{
 		public int codigo { get; set; }
 
 		public String mensagem { get; set; }
 
-		[XmlElementAttribute ("data-hora")]
+		[XmlElement ("data-hora")]
 		public String dataHora { get; set; }
 
 		public int valor { get; set; }

--- a/Cielo/Request/Element/AutorizacaoElement.cs
+++ b/Cielo/Request/Element/AutorizacaoElement.cs
@@ -1,18 +1,17 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Xml.Serialization;
 
-namespace Cielo.Request.Element
+namespace CieloEcommerce.Request.Element
 {
-	[SerializableAttribute ()]
-	[XmlTypeAttribute (Namespace = "http://ecommerce.cbmp.com.br")]
+	[Serializable ()]
+	[XmlType (Namespace = "http://ecommerce.cbmp.com.br")]
 	public partial class AutorizacaoElement :AbstractElement
 	{
 		public int codigo { get; set; }
 
 		public String mensagem { get; set; }
 
-		[XmlElementAttribute ("data-hora")]
+		[XmlElement ("data-hora")]
 		public String dataHora { get; set; }
 
 		public int valor { get; set; }

--- a/Cielo/Request/Element/DadosEcElement.cs
+++ b/Cielo/Request/Element/DadosEcElement.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Xml.Serialization;
 
-namespace Cielo.Request.Element
+namespace CieloEcommerce.Request.Element
 {
-	[SerializableAttribute ()]
-	[XmlTypeAttribute (Namespace = "http://ecommerce.cbmp.com.br")]
+	[Serializable ()]
+	[XmlType (Namespace = "http://ecommerce.cbmp.com.br")]
 	public partial class DadosEcElement :AbstractElement
 	{
 		public String numero { get; set; }

--- a/Cielo/Request/Element/DadosPedidoElement.cs
+++ b/Cielo/Request/Element/DadosPedidoElement.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Xml.Serialization;
 
-namespace Cielo.Request.Element
+namespace CieloEcommerce.Request.Element
 {
-	[SerializableAttribute ()]
-	[XmlTypeAttribute (Namespace = "http://ecommerce.cbmp.com.br")]
+	[Serializable ()]
+	[XmlType (Namespace = "http://ecommerce.cbmp.com.br")]
 	public partial class DadosPedidoElement :AbstractElement
 	{
 		public String numero { get; set; }
@@ -14,19 +13,19 @@ namespace Cielo.Request.Element
 
 		public int moeda { get; set; }
 
-		[XmlElementAttribute ("data-hora")]
+		[XmlElement ("data-hora")]
 		public String dataHora { get; set; }
 
-		[XmlElementAttribute ("descricao", IsNullable = false)]
+		[XmlElement ("descricao", IsNullable = false)]
 		public String descricao { get; set; }
 
-		[XmlElementAttribute ("idioma", IsNullable = false)]
+		[XmlElement ("idioma", IsNullable = false)]
 		public String idioma { get; set; }
 
-		[XmlElementAttribute ("taxa-embarque", IsNullable = false)]
+		[XmlElement ("taxa-embarque", IsNullable = false)]
 		public int taxaEmbarque { get; set; }
 
-		[XmlElementAttribute ("soft-descriptor")]
+		[XmlElement ("soft-descriptor")]
 		public String softDescriptor { get; set; }
 
 		public Order ToOrder ()

--- a/Cielo/Request/Element/DadosPortadorElement.cs
+++ b/Cielo/Request/Element/DadosPortadorElement.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Xml.Serialization;
 
-namespace Cielo.Request.Element
+namespace CieloEcommerce.Request.Element
 {
-	[SerializableAttribute ()]
-	[XmlTypeAttribute (Namespace = "http://ecommerce.cbmp.com.br")]
+	[Serializable ()]
+	[XmlType (Namespace = "http://ecommerce.cbmp.com.br")]
 	public partial class DadosPortadorElement :AbstractElement
 	{
 		public String numero { get; set; }
@@ -14,10 +13,10 @@ namespace Cielo.Request.Element
 
 		public String indicador { get; set; }
 
-		[XmlElementAttribute ("codigo-seguranca")]
+		[XmlElement ("codigo-seguranca")]
 		public String codigoSeguranca { get; set; }
 
-		[XmlElementAttribute ("nome-portador")]
+		[XmlElement ("nome-portador")]
 		public String nomePortador { get; set; }
 
 		public String token { get; set; }

--- a/Cielo/Request/Element/ErroElement.cs
+++ b/Cielo/Request/Element/ErroElement.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Xml.Serialization;
 
-namespace Cielo.Request.Element
+namespace CieloEcommerce.Request.Element
 {
-	[SerializableAttribute ()]
-	[XmlRootAttribute ("erro", Namespace = "http://ecommerce.cbmp.com.br", IsNullable = false)]
+	[Serializable ()]
+	[XmlRoot ("erro", Namespace = "http://ecommerce.cbmp.com.br", IsNullable = false)]
 	public partial class ErroElement :AbstractElement
 	{
 		public String codigo { get; set; }

--- a/Cielo/Request/Element/FormaPagamentoElement.cs
+++ b/Cielo/Request/Element/FormaPagamentoElement.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Xml.Serialization;
 
-namespace Cielo.Request.Element
+namespace CieloEcommerce.Request.Element
 {
-	[SerializableAttribute ()]
-	[XmlTypeAttribute (Namespace = "http://ecommerce.cbmp.com.br")]
+	[Serializable ()]
+	[XmlType (Namespace = "http://ecommerce.cbmp.com.br")]
 	public partial class FormaPagamentoElement
 	{
 		public String bandeira { get; set; }

--- a/Cielo/Request/Element/RetornoTokenElement.cs
+++ b/Cielo/Request/Element/RetornoTokenElement.cs
@@ -1,29 +1,28 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Xml.Serialization;
 
-namespace Cielo.Request.Element
+namespace CieloEcommerce.Request.Element
 {
-	[SerializableAttribute ()]
-	[XmlRootAttribute ("retorno-token", Namespace = "http://ecommerce.cbmp.com.br", IsNullable = false)]
+	[Serializable ()]
+	[XmlRoot ("retorno-token", Namespace = "http://ecommerce.cbmp.com.br", IsNullable = false)]
 	public class RetornoTokenElement :AbstractElement
 	{
-		[XmlTypeAttribute (Namespace = "http://ecommerce.cbmp.com.br")]
+		[XmlType (Namespace = "http://ecommerce.cbmp.com.br")]
 		public partial class DadosTokenElement
 		{
-			[XmlElementAttribute ("codigo-token")]
+			[XmlElement ("codigo-token")]
 			public String codigoToken { get; set; }
 
 			public int status { get; set; }
 
-			[XmlElementAttribute ("numero-cartao-truncado")]
+			[XmlElement ("numero-cartao-truncado")]
 			public String numeroTruncado { get; set; }
 		}
 
-		[XmlTypeAttribute (Namespace = "http://ecommerce.cbmp.com.br")]
+		[XmlType (Namespace = "http://ecommerce.cbmp.com.br")]
 		public partial class TokenElement
 		{
-			[XmlElementAttribute ("dados-token")]
+			[XmlElement ("dados-token")]
 			public DadosTokenElement dadosToken { get; set; }
 		}
 

--- a/Cielo/Request/Element/TokenElement.cs
+++ b/Cielo/Request/Element/TokenElement.cs
@@ -1,28 +1,25 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Xml.Serialization;
 
-namespace Cielo.Request.Element
+namespace CieloEcommerce.Request.Element
 {
-    [SerializableAttribute()]
-    [XmlTypeAttribute(Namespace = "http://ecommerce.cbmp.com.br")]
+    [Serializable()]
+    [XmlType(Namespace = "http://ecommerce.cbmp.com.br")]
     public class TokenElement : AbstractElement
     {
-        [XmlTypeAttribute(Namespace = "http://ecommerce.cbmp.com.br")]
+        [XmlType(Namespace = "http://ecommerce.cbmp.com.br")]
         public partial class DadosTokenElement
         {
-            [XmlElementAttribute("codigo-token")]
+            [XmlElement("codigo-token")]
             public String codigoToken { get; set; }
 
             public int status { get; set; }
 
-            [XmlElementAttribute("numero-cartao-truncado")]
+            [XmlElement("numero-cartao-truncado")]
             public String numeroTruncado { get; set; }
         }
 
-        [XmlElementAttribute("dados-token")]
+        [XmlElement("dados-token")]
         public DadosTokenElement dadosToken { get; set; }
 
         public Token ToToken()

--- a/Cielo/Request/Element/TransacaoElement.cs
+++ b/Cielo/Request/Element/TransacaoElement.cs
@@ -1,21 +1,20 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Xml.Serialization;
 
-namespace Cielo.Request.Element
+namespace CieloEcommerce.Request.Element
 {
-    [SerializableAttribute()]
-    [XmlRootAttribute("transacao", Namespace = "http://ecommerce.cbmp.com.br", IsNullable = false)]
+    [Serializable()]
+    [XmlRoot("transacao", Namespace = "http://ecommerce.cbmp.com.br", IsNullable = false)]
     public partial class TransacaoElement : AbstractElement
     {
         public String tid { get; set; }
 
         public String pan { get; set; }
 
-        [XmlElementAttribute("dados-pedido")]
+        [XmlElement("dados-pedido")]
         public DadosPedidoElement dadosPedido { get; set; }
 
-        [XmlElementAttribute("forma-pagamento")]
+        [XmlElement("forma-pagamento")]
         public FormaPagamentoElement formaPagamento { get; set; }
 
         public String status;
@@ -24,7 +23,7 @@ namespace Cielo.Request.Element
 
         public AutorizacaoElement autorizacao { get; set; }
 
-        [XmlElementAttribute("url-autenticacao")]
+        [XmlElement("url-autenticacao")]
         public String urlAutenticacao;
 
         public TokenElement token { get; set; }

--- a/Cielo/Request/TokenRequest.cs
+++ b/Cielo/Request/TokenRequest.cs
@@ -1,20 +1,20 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Xml.Serialization;
-using Cielo.Request.Element;
+using CieloEcommerce.Request.Element;
 
-namespace Cielo.Request
+namespace CieloEcommerce.Request
 {
-	[SerializableAttribute ()]
-	[DesignerCategoryAttribute ("code")]
-	[XmlTypeAttribute (Namespace = "http://ecommerce.cbmp.com.br")]
-	[XmlRootAttribute ("requisicao-token", Namespace = "http://ecommerce.cbmp.com.br", IsNullable = false)]
+	[Serializable ()]
+	[DesignerCategory ("code")]
+	[XmlType (Namespace = "http://ecommerce.cbmp.com.br")]
+	[XmlRoot ("requisicao-token", Namespace = "http://ecommerce.cbmp.com.br", IsNullable = false)]
 	public partial class TokenRequest :AbstractElement
 	{
-		[XmlElementAttribute ("dados-ec")]
+		[XmlElement ("dados-ec")]
 		public DadosEcElement dadosEc { get; set; }
 
-		[XmlElementAttribute ("dados-portador")]
+		[XmlElement ("dados-portador")]
 		public DadosPortadorElement dadosPortador { get; set; }
 
 		public static TokenRequest create (Transaction transaction)

--- a/Cielo/Request/TransactionRequest.cs
+++ b/Cielo/Request/TransactionRequest.cs
@@ -1,39 +1,38 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Xml.Serialization;
-using Cielo.Request.Element;
+using CieloEcommerce.Request.Element;
 
-namespace Cielo.Request
+namespace CieloEcommerce.Request
 {
-	[SerializableAttribute ()]
-	[XmlRootAttribute ("requisicao-transacao", Namespace = "http://ecommerce.cbmp.com.br", IsNullable = false)]
+	[Serializable ()]
+	[XmlRoot ("requisicao-transacao", Namespace = "http://ecommerce.cbmp.com.br", IsNullable = false)]
 	public partial class TransactionRequest :AbstractElement
 	{
-		[XmlElementAttribute ("dados-ec")]
+		[XmlElement ("dados-ec")]
 		public DadosEcElement dadosEc { get; set; }
 
-		[XmlElementAttribute ("dados-portador")]
+		[XmlElement ("dados-portador")]
 		public DadosPortadorElement dadosPortador { get; set; }
 
-		[XmlElementAttribute ("dados-pedido")]
+		[XmlElement ("dados-pedido")]
 		public DadosPedidoElement dadosPedido { get; set; }
 
-		[XmlElementAttribute ("forma-pagamento")]
+		[XmlElement ("forma-pagamento")]
 		public FormaPagamentoElement formaPagamento { get; set; }
 
-		[XmlElementAttribute ("url-retorno")]
+		[XmlElement ("url-retorno")]
 		public String urlRetorno { get; set; }
 
 		public int autorizar { get; set; }
 
 		public String capturar { get; set; }
 
-		[XmlElementAttribute ("campo-livre")]
+		[XmlElement ("campo-livre")]
 		public String campoLivre { get; set; }
 
 		public String bin { get; set; }
 
-		[XmlElementAttribute ("gerar-token")]
+		[XmlElement ("gerar-token")]
 		public String gerarToken { get; set; }
 
         public static TransactionRequest create (Transaction transaction)

--- a/Cielo/Token.cs
+++ b/Cielo/Token.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Cielo
+namespace CieloEcommerce
 {
 	/// <summary>
 	/// Representa um token do cartão do cliente para que possa ser armazenado

--- a/Cielo/Transaction.cs
+++ b/Cielo/Transaction.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Cielo
+namespace CieloEcommerce
 {
 	/// <summary>
 	/// Representação de uma transação

--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 Integração em C# com o Webservice Cielo 1.5
 
-## Setup
-
-Se preferir você pode pegar a versão mais recente diretamente do [pacote disponível](https://www.nuget.org/packages/CieloOficial/) na galeria do NuGet.
-
-> PM Install-Package CieloOficial
-
 ## Criando uma transação
 
 ```csharp

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Se preferir você pode pegar a versão mais recente diretamente do [pacote dispo
 ## Criando uma transação
 
 ```csharp
+using CieloEcommerce;
+//...
 String mid = "1006993069";
 String key = "25fbb99741c739dd84d7b06ec78c9bac718838630f30b112d033ce2e621b34f3";
 
@@ -39,6 +41,7 @@ Transaction transaction = cielo.transactionRequest (
 ## Criando uma transação e enviando para autorização
 
 ```csharp
+using CieloEcommerce;
 //...
 
 try {
@@ -65,6 +68,7 @@ try {
 ## Exemplo de consulta
 
 ```csharp
+using CieloEcommerce;
 //...
 
 
@@ -79,6 +83,7 @@ try {
 ## Cancelamento total de uma transação
 
 ```csharp
+using CieloEcommerce;
 //...
 
 
@@ -93,6 +98,7 @@ try {
 ## Captura total de uma transação
 
 ```csharp
+using CieloEcommerce;
 //...
 
 
@@ -107,6 +113,7 @@ try {
 ## Captura parcial de uma transação
 
 ```csharp
+using CieloEcommerce;
 //...
 
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Integração em C# com o Webservice Cielo 1.5
 
+## Setup
+
+Se preferir você pode pegar a versão mais recente diretamente do [pacote disponível](https://www.nuget.org/packages/CieloOficial/) na galeria do NuGet.
+
+> PM Install-Package CieloOficial
+
 ## Criando uma transação
 
 ```csharp

--- a/TesteUnidadeCielo/ConfigApp.cs
+++ b/TesteUnidadeCielo/ConfigApp.cs
@@ -12,7 +12,7 @@ namespace Cielo
         //DEBUG
         internal const string key = "25fbb99741c739dd84d7b06ec78c9bac718838630f30b112d033ce2e621b34f3";
         internal const string mid = "1006993069"; //id loja
-        internal const string UrlCieloEcommerce = Cielo.TEST;
+        internal const string UrlCieloEcommerce = CieloEcommerce.Cielo.TEST;
         internal const string UrlRetornoAPP = "https://localhost:47451/";
 
 

--- a/TesteUnidadeCielo/Teste.cs
+++ b/TesteUnidadeCielo/Teste.cs
@@ -1,6 +1,7 @@
 ﻿using Cielo;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using CieloEcommerce;
 
 namespace TesteUnidadeCielo
 {
@@ -10,7 +11,7 @@ namespace TesteUnidadeCielo
         [TestMethod]
         public void TestarTransacao()
         {
-            var cielo = new Cielo.Cielo(ConfigApp.mid, ConfigApp.key, ConfigApp.UrlCieloEcommerce);
+            var cielo = new CieloEcommerce.Cielo(ConfigApp.mid, ConfigApp.key, ConfigApp.UrlCieloEcommerce);
 
             var holder = cielo.holder("4012001038443335", "2018", "05", "123");
             holder.name = "Fulano Portador da Silva";
@@ -37,7 +38,7 @@ namespace TesteUnidadeCielo
         [TestMethod]
         public void TestarTransacaoComToken()
         {
-            var cielo = new Cielo.Cielo(ConfigApp.mid, ConfigApp.key, ConfigApp.UrlCieloEcommerce);
+            var cielo = new CieloEcommerce.Cielo(ConfigApp.mid, ConfigApp.key, ConfigApp.UrlCieloEcommerce);
 
             var holder = cielo.holder("4012001038443335", "2018", "05", "123");
             holder.name = "Fulano Portador da Silva";
@@ -66,7 +67,7 @@ namespace TesteUnidadeCielo
         [TestMethod]
         public void TestarCancelarTransacao()
         {
-            var cielo = new Cielo.Cielo(ConfigApp.mid, ConfigApp.key, ConfigApp.UrlCieloEcommerce);
+            var cielo = new CieloEcommerce.Cielo(ConfigApp.mid, ConfigApp.key, ConfigApp.UrlCieloEcommerce);
 
             //executa uma transacao
             #region Transacao de teste


### PR DESCRIPTION
Conforme definido no #22 o namespace do projeto foi alterado de Cielo para CieloEcommerce a fim de evitar colisões de nomes entre ele e a classe principal.

Nenhuma quebra foi identificada no projeto e o teste de unidade continua passando.